### PR TITLE
Kafka consumer order status

### DIFF
--- a/ecommerce-order-service/pom.xml
+++ b/ecommerce-order-service/pom.xml
@@ -88,6 +88,13 @@
 			<version>2.8.5</version>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/org.springframework.kafka/spring-kafka -->
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+			<version>3.3.4</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/ecommerce-order-service/src/main/java/com/example/ecommerce_order_service/DTO/PaymentConfirmedEvent.java
+++ b/ecommerce-order-service/src/main/java/com/example/ecommerce_order_service/DTO/PaymentConfirmedEvent.java
@@ -1,0 +1,9 @@
+package com.example.ecommerce_order_service.DTO;
+
+import lombok.Data;
+
+@Data
+public class PaymentConfirmedEvent {
+    private Long orderId;
+    private String status;
+}

--- a/ecommerce-order-service/src/main/java/com/example/ecommerce_order_service/kafka/PaymentConfirmedListener.java
+++ b/ecommerce-order-service/src/main/java/com/example/ecommerce_order_service/kafka/PaymentConfirmedListener.java
@@ -1,0 +1,31 @@
+package com.example.ecommerce_order_service.kafka;
+
+import com.example.ecommerce_order_service.DTO.PaymentConfirmedEvent;
+import com.example.ecommerce_order_service.entities.OrderStatus;
+import com.example.ecommerce_order_service.services.IOrderService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PaymentConfirmedListener {
+    private final IOrderService orderService;
+
+    public PaymentConfirmedListener(@Qualifier("OrderServiceImpl") IOrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @KafkaListener(topics = "payment-confirmed", groupId = "order-service-group", containerFactory = "kafkaListenerContainerFactory")
+    public void handlePaymentConfirmedEvent(PaymentConfirmedEvent event) {
+        log.info("✅ Received payment-confirmed event: {}", event);
+
+        if("PAID".equalsIgnoreCase(event.getStatus())) {
+            orderService.updateOrderStatus(event.getOrderId(), OrderStatus.PAID);
+            log.info("📦 Order #{} marked as PAID", event.getOrderId());
+        } else {
+            log.warn("⚠️ Unexpected payment status: {}", event.getStatus());
+        }
+    }
+}

--- a/ecommerce-order-service/src/main/resources/application.properties
+++ b/ecommerce-order-service/src/main/resources/application.properties
@@ -9,6 +9,15 @@ spring.datasource.password=springstudent
 # JPA and Hibernate Configurations
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
-``
 
 jwt.secret=g+msj/YY6Mz+bkdf6F05zaqdJRYwuu7Wo3yVE6AjhsU=
+
+
+
+# Kafka configuration
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.consumer.group-id=order-service-group
+spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.properties.spring.json.trusted.packages=*


### PR DESCRIPTION
###  Kafka Consumer: Update Order Status from Payment Events

This PR introduces a Kafka consumer to the `ecommerce-order-service` that listens to `payment-confirmed` events and updates the corresponding order status to `PAID`.

---

###  What’s Added

- **Kafka Configuration**  
  - Added Kafka consumer settings to `application.properties`
  - Configured group ID, deserializers, and trusted packages

- **DTO**  
  - `PaymentConfirmedEvent.java`: carries `orderId` and `status` fields (e.g., `PAID`)

- **Consumer Listener**  
  - `PaymentConfirmedListener.java`: listens to the `payment-confirmed` Kafka topic
  - Automatically updates order status in the database via service layer
  
---
  ### Testing Notes

You can test this by:
1. Triggering a successful payment from the payment service (Stripe mock or real)
2. Confirm the event is published to Kafka (`payment-confirmed` topic)
3. Watch the `ecommerce-order-service` consume the event and update the order record
